### PR TITLE
added option to use different test-statistics than p-value in summarise_test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SimNPH
 Type: Package
 Title: Simulate Non-Proportional Hazards
-Version: 0.5.8
+Version: 0.5.9
 Authors@R: c(person("Tobias", "Fellinger", email="tobias.fellinger@ages.at", role=c("aut", "cre"), comment = c(ORCID = "0000-0001-9474-2731")),
             person("Florian", "Klinglmueller", role=c("aut"), comment = c(ORCID = "0000-0002-7346-3669")))
 License: BSL-1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# SimNPH 0.5.9
+
+* Added an option to use different test-statistics, or p-values from different
+  tests in `summarise_test` if an analysis function returns results from
+  multiple tests.
+
 # SimNPH 0.5.8
 
 * Fixed tests: test plots with `vdiffr` to avoid using non-exported functions

--- a/R/SimNPH-package.R
+++ b/R/SimNPH-package.R
@@ -23,5 +23,5 @@ NULL
 # dplyr verbs and ggplot calls.
 globalVariables(c(
   "interval", "trt", "method", "x", "name", "value", "level", "y", "n_pat",
-  "surv_a", "surv_b", "haz_a", "haz_b", "hr", "x_split"
+  "surv_a", "surv_b", "haz_a", "haz_b", "hr", "x_split", "p"
 ))

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -259,9 +259,17 @@ summarise_estimator <- function(est, real, lower=NULL, upper=NULL, null=NULL, es
 
 #' Generic summarise function for tests
 #'
-#' @param alpha the significance level(s)
+#' @param alpha the significance level(s) or critical value(s)
 #' @param name name for the summarise function,
 #' appended to the name of the analysis method in the final results
+#' @param teststat test statistic, expression evaluated in results
+#'
+#' @details
+#' For details on the evaluation of the arguments see \link[SimNPH]{summarise_estimator}.
+#'
+#' If the test-statistic used is not a p-value, alpha refers to the critical
+#' value. The test is assumed to reject if the test statistic is smaller than
+#' the critical value. To switch direction take the negative of both values.
 #'
 #' @return
 #'
@@ -286,7 +294,8 @@ summarise_estimator <- function(est, real, lower=NULL, upper=NULL, null=NULL, es
 #'   head(1)
 #'
 #' summarise_all <- create_summarise_function(
-#'   logrank=summarise_test(alpha=c(0.5, 0.9, 0.95, 0.99))
+#'   logrank=summarise_test(alpha=1-c(0.5, 0.9, 0.95, 0.99)),
+#'   logrank_zval=summarise_test(alpha=qnorm(1-c(0.5, 0.9, 0.95, 0.99)), teststat=z)
 #' )
 #'
 #' # runs simulations
@@ -295,22 +304,33 @@ summarise_estimator <- function(est, real, lower=NULL, upper=NULL, null=NULL, es
 #'   replications=100,
 #'   generate=generate_delayed_effect,
 #'   analyse=list(
-#'     logrank=analyse_logrank()
+#'     logrank=analyse_logrank(),
+#'     logrank_zval=function(condition, dat, fixed_objects=NULL){
+#'       tmp <- analyse_logrank()(condition, dat, fixed_objects)
+#'       tmp$z <- qnorm(tmp$p)
+#'       tmp
+#'     }
 #'   ),
 #'   summarise = summarise_all
 #' )
 #'
 #' sim_results[, grepl("rejection", names(sim_results))]
 #' }
-summarise_test <- function(alpha, name=NULL){
+summarise_test <- function(alpha, name=NULL, teststat=p){
+
+  teststat <- substitute(teststat)
+
   res <- function(condition, results, fixed_objects){
-    rejection_tmp <- outer(results$p, alpha, FUN=`<`) |>
+
+    teststat <- eval(teststat, envir = results)
+
+    rejection_tmp <- outer(teststat, alpha, FUN=`<`) |>
       colMeans(na.rm=TRUE) |>
       as.list() |>
       as.data.frame() |>
       setNames(paste0("rejection_", alpha))
 
-    missing_tmp <- outer(results$p, 1-alpha, FUN=\(p,a){is.na(p)}) |>
+    missing_tmp <- outer(teststat, 1-alpha, FUN=\(p,a){is.na(p)}) |>
       colSums() |>
       as.list() |>
       as.data.frame() |>

--- a/man/summarise_test.Rd
+++ b/man/summarise_test.Rd
@@ -4,13 +4,15 @@
 \alias{summarise_test}
 \title{Generic summarise function for tests}
 \usage{
-summarise_test(alpha, name = NULL)
+summarise_test(alpha, name = NULL, teststat = p)
 }
 \arguments{
-\item{alpha}{the significance level(s)}
+\item{alpha}{the significance level(s) or critical value(s)}
 
 \item{name}{name for the summarise function,
 appended to the name of the analysis method in the final results}
+
+\item{teststat}{test statistic, expression evaluated in results}
 }
 \value{
 A function that can be used in Summarise that returns a data frame with the columns
@@ -25,6 +27,13 @@ Where X, Y, ... are the alpha levels given in the argument
 \description{
 Generic summarise function for tests
 }
+\details{
+For details on the evaluation of the arguments see \link[SimNPH]{summarise_estimator}.
+
+If the test-statistic used is not a p-value, alpha refers to the critical
+value. The test is assumed to reject if the test statistic is smaller than
+the critical value. To switch direction take the negative of both values.
+}
 \examples{
 \donttest{
 condition <- merge(
@@ -36,7 +45,8 @@ condition <- merge(
   head(1)
 
 summarise_all <- create_summarise_function(
-  logrank=summarise_test(alpha=c(0.5, 0.9, 0.95, 0.99))
+  logrank=summarise_test(alpha=1-c(0.5, 0.9, 0.95, 0.99)),
+  logrank_zval=summarise_test(alpha=qnorm(1-c(0.5, 0.9, 0.95, 0.99)), teststat=z)
 )
 
 # runs simulations
@@ -45,7 +55,12 @@ sim_results <- runSimulation(
   replications=100,
   generate=generate_delayed_effect,
   analyse=list(
-    logrank=analyse_logrank()
+    logrank=analyse_logrank(),
+    logrank_zval=function(condition, dat, fixed_objects=NULL){
+      tmp <- analyse_logrank()(condition, dat, fixed_objects)
+      tmp$z <- qnorm(tmp$p)
+      tmp
+    }
   ),
   summarise = summarise_all
 )

--- a/tests/testthat/test-summarise.R
+++ b/tests/testthat/test-summarise.R
@@ -157,34 +157,45 @@ test_that("generic summarise for tests works", {
       tail(4) |>
       head(1)
   )
+
   summarise_all <- create_summarise_function(
-    logrank=summarise_test(alpha=c(0.95, 0.99)),
-    logrank=summarise_test(alpha=c(0.9), name="innovative")
+    logrank=summarise_test(alpha=1-c(0.95, 0.99)),
+    logrank=summarise_test(alpha=1-c(0.9), name="innovative"),
+    logrank=summarise_test(alpha=1-c(0.95, 0.99), name="p_explicit", teststat=p),
+    test_analysis=summarise_test(alpha=qnorm(1-0.95), name="z_stat", teststat=z),
+    test_analysis=summarise_test(alpha=1-0.95, name="p_stat", teststat=p)
   )
 
-  # TODO: remove caputre warnings when sessioninfo is fixed
+  # TODO: remove capture warnings when sessioninfo is fixed
   tmp_output <- capture_warnings(
     # runs simulations
     capture.output(
       suppressMessages(
+
         sim_results <- runSimulation(
           design=condition,
           replications=10,
           generate=generate_delayed_effect,
           analyse=list(
-            logrank=analyse_logrank()
+            logrank=analyse_logrank(),
+            test_analysis=function(condition, dat, fixed_objects=NULL){
+              tmp <- analyse_logrank()(condition, dat, fixed_objects)
+              tmp$z <- qnorm(tmp$p)
+              tmp
+            }
           ),
           summarise = summarise_all,
           save=FALSE
         )
+
       )
     )
   )
 
   expect(
     all(hasName(sim_results, c(
-      "logrank.rejection_0.95", "logrank.rejection_0.99", "logrank.innovative.rejection_0.9",
-      "logrank.N_missing_0.95", "logrank.N_missing_0.99", "logrank.innovative.N_missing_0.9",
+      "logrank.rejection_0.05", "logrank.rejection_0.01", "logrank.innovative.rejection_0.1",
+      "logrank.N_missing_0.05", "logrank.N_missing_0.01", "logrank.innovative.N_missing_0.1",
       "logrank.mean_n_pat", "logrank.sd_n_pat", "logrank.mean_n_evt", "logrank.sd_n_evt",
       "logrank.N"
       ))),
@@ -193,14 +204,22 @@ test_that("generic summarise for tests works", {
 
 
 
-  expect_gte(sim_results$logrank.rejection_0.95,           0)
-  expect_gte(sim_results$logrank.rejection_0.99,           0)
-  expect_gte(sim_results$logrank.innovative.rejection_0.9, 0)
-  expect_lte(sim_results$logrank.rejection_0.95,           1)
-  expect_lte(sim_results$logrank.rejection_0.99,           1)
-  expect_lte(sim_results$logrank.innovative.rejection_0.9, 1)
+  expect_gte(sim_results$logrank.rejection_0.05,           0)
+  expect_gte(sim_results$logrank.rejection_0.01,           0)
+  expect_gte(sim_results$logrank.innovative.rejection_0.1, 0)
+  expect_lte(sim_results$logrank.rejection_0.05,           1)
+  expect_lte(sim_results$logrank.rejection_0.01,           1)
+  expect_lte(sim_results$logrank.innovative.rejection_0.1, 1)
   expect_equal(sim_results$logrank.innovative.sd_n_pat, 0)
   expect_equal(sim_results$logrank.innovative.mean_n_evt, 300)
+
+  expect_all_equal(c(
+    sim_results$logrank.p_explicit.rejection_0.05,
+    sim_results$`test_analysis.z_stat.rejection_-1.64485362695147`,
+    sim_results$test_analysis.p_stat.rejection_0.05
+    ),
+    sim_results$logrank.rejection_0.05
+    )
 })
 
 test_that("missings are treated correctly for summarise estimator", {
@@ -235,6 +254,7 @@ test_that("missings are treated correctly for summarise estimator", {
 
 test_that("missings are treated correctly for summarise test", {
   my_summarise <- summarise_test(alpha = c(0.05, 0.01))
+  my_summarise2 <- summarise_test(alpha = qnorm(c(0.05, 0.01)), teststat=z)
 
   condition_and_results <- tibble::tribble(
     ~real,       ~p,
@@ -242,15 +262,25 @@ test_that("missings are treated correctly for summarise test", {
         0,    0.04 ,
         0,    0.1  ,
         0, NA_real_,
-  )
+  ) |>
+    transform(
+      z = qnorm(p)
+    )
 
   my_results <- my_summarise(condition_and_results, condition_and_results)
+  my_results2 <- my_summarise2(condition_and_results, condition_and_results)
 
   expect_equal(my_results$rejection_0.05, 2/3)
   expect_equal(my_results$rejection_0.01, 1/3)
   expect_equal(my_results$N_missing_0.05, 1)
   expect_equal(my_results$N_missing_0.01, 1)
   expect_equal(my_results$N, 4)
+
+  expect_equal(my_results2$`rejection_-1.64485362695147`, 2/3)
+  expect_equal(my_results2$`rejection_-2.32634787404084`, 1/3)
+  expect_equal(my_results2$`N_missing_-1.64485362695147`, 1)
+  expect_equal(my_results2$`N_missing_-2.32634787404084`, 1)
+  expect_equal(my_results2$N, 4)
 })
 
 test_that("calculations in summarise estimator work", {


### PR DESCRIPTION
Added option to use arbitrary fields of the output as test-statistic in summarise_test. Previously this could only handle the p value stored in the field "p".

The argument alpha is interpreted as critical value if other test-statistics than p-values are used. The test rejects if the test statistic is **below** the critical value (like when the test-statistic is a p-value and the critical value is a significance level), to reverse this one can simply use the negative of both values.